### PR TITLE
PLATFORM-1886 Add on resolved callbacks

### DIFF
--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pydoc import locate
-from typing import Any, Dict, List, Optional, Union, Set, Tuple
+from typing import Any, Dict, List, Optional, Union, Set, Tuple, Callable
 
 from pypendency import exceptions
 from pypendency.argument import Argument
@@ -22,6 +22,7 @@ class AbstractContainer(ABC):
 class Container(AbstractContainer):
     def __init__(self, definitions: List[Definition]):
         self._resolved = False
+        self._resolved_callbacks: Set[Callable] = set()
         self._service_mapping: Dict[str, Union[None, object, Definition]] = {
             definition.identifier: definition
             for definition in definitions
@@ -34,6 +35,15 @@ class Container(AbstractContainer):
 
         self.__populate_tags_map()
         self._resolved = True
+        self.__perform_on_resolved_callbacks()
+
+
+    def add_resolved_callback(self, func: Callable) -> None:
+        self._resolved_callbacks.add(func)
+
+    def __perform_on_resolved_callbacks(self):
+        for callback in self._resolved_callbacks:
+            callback()
 
     def is_resolved(self) -> bool:
         return self._resolved

--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pydoc import locate
-from typing import Any, Dict, List, Optional, Union, Set, Callable
+from typing import Any, Dict, List, Optional, Union, Set
 
 from pypendency import exceptions
 from pypendency.argument import Argument

--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, List, Optional, Union, Set, Callable
 from pypendency import exceptions
 from pypendency.argument import Argument
 from pypendency.definition import Definition
+from pypendency.on_container_resolved_callable import OnContainerResolvedCallable
 from pypendency.tag import Tag
 
-ResolveCallable = Callable[[], None]
 
 class AbstractContainer(ABC):
     @abstractmethod
@@ -23,7 +23,7 @@ class AbstractContainer(ABC):
 class Container(AbstractContainer):
     def __init__(self, definitions: List[Definition]):
         self._resolved = False
-        self._on_resolved_callbacks: Set[ResolveCallable] = set()
+        self._on_resolved_callbacks: Set[OnContainerResolvedCallable] = set()
         self._service_mapping: Dict[str, Union[None, object, Definition]] = {
             definition.identifier: definition
             for definition in definitions
@@ -38,8 +38,7 @@ class Container(AbstractContainer):
         self._resolved = True
         self.__perform_on_resolved_callbacks()
 
-
-    def add_on_resolved_callback(self, func: ResolveCallable) -> None:
+    def add_on_resolved_callback(self, func: OnContainerResolvedCallable) -> None:
         self._on_resolved_callbacks.add(func)
 
     def __perform_on_resolved_callbacks(self) -> None:

--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -38,16 +38,6 @@ class Container(AbstractContainer):
         self._resolved = True
         self.__perform_on_resolved_callbacks()
 
-    def add_on_resolved_callback(self, func: OnContainerResolvedCallable) -> None:
-        self._on_resolved_callbacks.add(func)
-
-    def __perform_on_resolved_callbacks(self) -> None:
-        for on_resolved_callback in self._on_resolved_callbacks:
-            try:
-                on_resolved_callback()
-            except Exception as e:
-                raise exceptions.PypendencyCallbackException() from e
-
     def is_resolved(self) -> bool:
         return self._resolved
 
@@ -60,6 +50,16 @@ class Container(AbstractContainer):
 
     def __add_service_to_tag_group(self, tag: Tag, service_identifier: str) -> None:
         self._tags_mapping.setdefault(tag, set()).add(service_identifier)
+
+    def __perform_on_resolved_callbacks(self) -> None:
+        for on_resolved_callback in self._on_resolved_callbacks:
+            try:
+                on_resolved_callback()
+            except Exception as e:
+                raise exceptions.PypendencyCallbackException() from e
+
+    def add_on_resolved_callback(self, func: OnContainerResolvedCallable) -> None:
+        self._on_resolved_callbacks.add(func)
 
     def set(self, identifier: str, service: object, tags: Optional[Set[Tag]] = None) -> None:
         if self.is_resolved():

--- a/src/pypendency/exceptions.py
+++ b/src/pypendency/exceptions.py
@@ -47,4 +47,4 @@ class TagNotFoundInContainer(Exception):
 
 class PypendencyCallbackException(Exception):
     def __init__(self) -> None:
-        super().__init__(f"Bad on_resolved_callback")
+        super().__init__(f"Exception on_resolved_callback")

--- a/src/pypendency/exceptions.py
+++ b/src/pypendency/exceptions.py
@@ -34,7 +34,6 @@ class ServiceNotFoundFromFullyQualifiedName(Exception):
             f"Container can't locate any class in {fully_qualified_name}"
         )
 
-
 class ServiceInstantiationFailed(Exception):
     def __init__(self, service_fqn: str) -> None:
         self.service_fqn = service_fqn
@@ -45,3 +44,7 @@ class TagNotFoundInContainer(Exception):
     def __init__(self, tag_identifier: str) -> None:
         self.tag_identifier = tag_identifier
         super().__init__(f"The tag '{tag_identifier}' does not exist in the container")
+
+class PypendencyCallbackException(Exception):
+    def __init__(self) -> None:
+        super().__init__(f"Bad on_resolved_callback")

--- a/src/pypendency/on_container_resolved_callable.py
+++ b/src/pypendency/on_container_resolved_callable.py
@@ -1,0 +1,3 @@
+from typing import Callable
+
+OnContainerResolvedCallable = Callable[[], None]

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -246,3 +246,14 @@ class TestContainer(TestCase):
 
         with self.assertRaises(exceptions.PypendencyCallbackException):
             container.resolve()
+
+    def test_set_dependency_on_resolved_callback(self):
+        container = Container([])
+
+        def func_one() -> None:
+            container.set("fqn", 1)
+        func_one.side_effect = Exception()
+        container.add_on_resolved_callback(func_one)
+
+        with self.assertRaises(exceptions.PypendencyCallbackException):
+            container.resolve()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -252,7 +252,7 @@ class TestContainer(TestCase):
 
         def func_one() -> None:
             container.set("fqn", 1)
-        func_one.side_effect = Exception()
+
         container.add_on_resolved_callback(func_one)
 
         with self.assertRaises(exceptions.PypendencyCallbackException):

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import sentinel
+from unittest.mock import sentinel, Mock
 
 from pypendency import exceptions
 from pypendency.argument import Argument
@@ -204,3 +204,38 @@ class TestContainer(TestCase):
         ])
         self.assertTrue(container.has("example"))
         self.assertFalse(container.has("other_example"))
+
+    def test_add_resolved_callback(self):
+        container = Container([])
+        func_one = Mock()
+        container.add_resolved_callback(func_one)
+        self.assertEqual(1, len(container._resolved_callbacks))
+
+        container.add_resolved_callback(func_one)
+        self.assertEqual(1, len(container._resolved_callbacks))
+        func_two = Mock()
+        func_three = Mock()
+        container.add_resolved_callback(func_two)
+        container.add_resolved_callback(func_three)
+
+        self.assertEqual(3, len(container._resolved_callbacks))
+
+    def test__perform_on_resolved_callbacks(self):
+        container = Container([])
+
+        func_one = Mock()
+        func_two = Mock()
+        func_three = Mock()
+
+        container.add_resolved_callback(func_one)
+        container.add_resolved_callback(func_two)
+        container.add_resolved_callback(func_three)
+
+        container.resolve()
+
+        func_one.assert_called_once()
+        func_two.assert_called_once()
+        func_three.assert_called_once()
+
+
+

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -208,28 +208,28 @@ class TestContainer(TestCase):
     def test_add_resolved_callback(self):
         container = Container([])
         func_one = Mock()
-        container.add_resolved_callback(func_one)
-        self.assertEqual(1, len(container._resolved_callbacks))
+        container.add_on_resolved_callback(func_one)
+        self.assertEqual(1, len(container._on_resolved_callbacks))
 
-        container.add_resolved_callback(func_one)
-        self.assertEqual(1, len(container._resolved_callbacks))
+        container.add_on_resolved_callback(func_one)
+        self.assertEqual(1, len(container._on_resolved_callbacks))
         func_two = Mock()
         func_three = Mock()
-        container.add_resolved_callback(func_two)
-        container.add_resolved_callback(func_three)
+        container.add_on_resolved_callback(func_two)
+        container.add_on_resolved_callback(func_three)
 
-        self.assertEqual(3, len(container._resolved_callbacks))
+        self.assertEqual(3, len(container._on_resolved_callbacks))
 
-    def test__perform_on_resolved_callbacks(self):
+    def test_perform_on_resolved_callbacks(self):
         container = Container([])
 
         func_one = Mock()
         func_two = Mock()
         func_three = Mock()
 
-        container.add_resolved_callback(func_one)
-        container.add_resolved_callback(func_two)
-        container.add_resolved_callback(func_three)
+        container.add_on_resolved_callback(func_one)
+        container.add_on_resolved_callback(func_two)
+        container.add_on_resolved_callback(func_three)
 
         container.resolve()
 
@@ -237,5 +237,12 @@ class TestContainer(TestCase):
         func_two.assert_called_once()
         func_three.assert_called_once()
 
+    def test_perform_on_resolved_callbacks_exception(self):
+        container = Container([])
 
+        func_one = Mock()
+        func_one.side_effect = Exception()
+        container.add_on_resolved_callback(func_one)
 
+        with self.assertRaises(exceptions.PypendencyCallbackException):
+            container.resolve()


### PR DESCRIPTION
# Add on resolved callbacks

## Summary
Enhance the container's functionality by incorporating a set-based subscriber mechanism to receive notifications when the container is resolved.

## Tasks done
- Add functionality to container
- Add unit tests

## Before merge
- [ ] Talk with @jorgemo-fever and @lpl to discuss this

## How-To Test

- [ ] Copy src to a project, Transactional-api for example
- [ ] Register several callbacks in container with logs
- [ ] Force a resolved in the container by getting a dependency or using the `resolve` method and see the logs of the registered callbacks
