### PR TITLE
PLATFORM-1762 Create get_services_identifiers_by_tag_name method at container

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='pypendency',
-    version='0.4.0',
+    version='0.5.0',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     author='Fever - Platform Squad',

--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -125,20 +125,6 @@ class Container(AbstractContainer):
         except TypeError as e:
             raise exceptions.ServiceInstantiationFailed(fully_qualified_name) from e
 
-    def get_service_identifier(self, service: Union[object, Definition]) -> str:
-        if self.is_resolved() is False:
-            self.resolve()
-
-        matching_identifiers: Set[str] = {k for k, v in self._service_mapping.items() if v == service}
-
-        if len(matching_identifiers) == 0:
-            raise exceptions.ServiceNotFoundInContainer(service.__str__())
-
-        if len(matching_identifiers) > 1:
-            raise exceptions.ServiceIsRegisteredWithMultipleIdentifiers(service)
-
-        return matching_identifiers.pop()
-
     def get_by_tag(self, tag: Tag) -> Set[object]:
         if self.is_resolved() is False:
             self.resolve()
@@ -159,6 +145,31 @@ class Container(AbstractContainer):
                     services.add(self._do_get(tagged_service))
 
         return services
+
+    def get_services_identifiers_by_tag_name(self, tag_identifier: str,
+                                             tag_value: Optional[object] = Tag.UNSET_VALUE) -> Set[str]:
+        if self.is_resolved() is False:
+            self.resolve()
+
+        if tag_value != Tag.UNSET_VALUE:
+            return self._do_get_services_identifiers_by_tag(Tag(identifier=tag_identifier, value=tag_value))
+
+        identifiers: Set[str] = set()
+        for tag, tagged_services in self._tags_mapping.items():
+            if tag.identifier == tag_identifier:
+                for service in tagged_services:
+                    identifiers.add(service)
+
+        if len(identifiers) == 0:
+            raise exceptions.TagNotFoundInContainer(tag_identifier)
+
+        return identifiers
+
+    def _do_get_services_identifiers_by_tag(self, tag: Tag) -> Set[str]:
+        if tag not in self._tags_mapping:
+            raise exceptions.TagNotFoundInContainer(tag.identifier)
+
+        return set(self._tags_mapping[tag])
 
     def get_service_tags(self, service_identifier: str) -> Set[Tag]:
         if self.is_resolved() is False:

--- a/src/pypendency/exceptions.py
+++ b/src/pypendency/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Union
+
+from pypendency.definition import Definition
 from pypendency.tag import Tag
 
 
@@ -34,6 +37,7 @@ class ServiceNotFoundFromFullyQualifiedName(Exception):
             f"Container can't locate any class in {fully_qualified_name}"
         )
 
+
 class ServiceInstantiationFailed(Exception):
     def __init__(self, service_fqn: str) -> None:
         self.service_fqn = service_fqn
@@ -45,6 +49,13 @@ class TagNotFoundInContainer(Exception):
         self.tag_identifier = tag_identifier
         super().__init__(f"The tag '{tag_identifier}' does not exist in the container")
 
+
 class PypendencyCallbackException(Exception):
     def __init__(self) -> None:
         super().__init__(f"Exception on_resolved_callback")
+
+
+class ServiceIsRegisteredWithMultipleIdentifiers(Exception):
+    def __init__(self, service: Union[object, Definition]) -> None:
+        self.service = service
+        super().__init__(f"The service {service} is registered with multiple identifiers")

--- a/src/pypendency/exceptions.py
+++ b/src/pypendency/exceptions.py
@@ -53,9 +53,3 @@ class TagNotFoundInContainer(Exception):
 class PypendencyCallbackException(Exception):
     def __init__(self) -> None:
         super().__init__(f"Exception on_resolved_callback")
-
-
-class ServiceIsRegisteredWithMultipleIdentifiers(Exception):
-    def __init__(self, service: Union[object, Definition]) -> None:
-        self.service = service
-        super().__init__(f"The service {service} is registered with multiple identifiers")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -198,6 +198,31 @@ class TestContainer(TestCase):
         self.assertEqual(1, len(tags))
         self.assertEqual(list(tags)[0], test_tag)
 
+    def test_get_service_identifier_raises_when_registered_multiple_times(self):
+        container = Container([])
+        test_service = object()
+        container.set("test_service", test_service)
+        container.set("another_test_service", test_service)
+
+        with self.assertRaises(exceptions.ServiceIsRegisteredWithMultipleIdentifiers):
+            container.get_service_identifier(test_service)
+
+    def test_get_service_identifier_raises_when_service_not_registered(self):
+        container = Container([])
+        test_service = object()
+
+        with self.assertRaises(exceptions.ServiceNotFoundInContainer):
+            container.get_service_identifier(test_service)
+
+    def test_get_service_identifier(self):
+        container = Container([])
+        test_service = object()
+        container.set("test_service", test_service)
+
+        identifier = container.get_service_identifier(test_service)
+
+        self.assertEqual("test_service", identifier)
+
     def test_has(self):
         container = Container([
             Definition("example", "example.fqn"),


### PR DESCRIPTION
PLATFORM-1762

#### Description
Tags would get advantage of this functionality and it is needed for implementing it at Transactional API.

#### How to test
- [ ] Locally install this version of pypendency.
- [ ] Register a service and then call the new method to obtain the services identifiers
- [ ] Test also the edge case: service not registered