### PR TITLE
Fix the Docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Build Docker image
         run: |
-          docker build . -t pypendency-dev --build-arg PYTHON_VERSION=${{ matrix.python-version }}
+          docker build . -t pypendency-dev:python-${{ matrix.python-version }} --build-arg PYTHON_VERSION=${{ matrix.python-version }}
       - name: Unittest
         run: |
-          docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"
+          docker run -v $(pwd)/.:/usr/src/app pypendency-dev:python-${{ matrix.python-version }} bash -c "pipenv run make run-tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Build Docker image
         run: |
-          docker build . -t pypendency-dev
+          docker build . -t pypendency-dev --build-var PYTHON_VERSION=${{ matrix.python-version }}
       - name: Unittest
         run: |
           docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Build Docker image
         run: |
-          docker build . -t pypendency-dev --build-var PYTHON_VERSION=${{ matrix.python-version }}
+          docker build . -t pypendency-dev --build-arg PYTHON_VERSION=${{ matrix.python-version }}
       - name: Unittest
         run: |
           docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,9 @@ jobs:
     name: Pypendency tests on ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@master
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Build Docker image
         run: |
-          python -m pip install --upgrade pip
-          pip install pipenv
-          pipenv install --dev
+          docker build . -t pypendency-dev
       - name: Unittest
-        env:
-          PYTHONPATH: ${PYTHONPATH}:${PWD}:src/
         run: |
-          pipenv run make run-tests
+          docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /usr/src/app
 COPY Pipfile /usr/src/app/Pipfile
 COPY Pipfile.lock /usr/src/app/Pipfile.lock
 
-RUN pip install pipenv
+RUN apt-get update && \
+    apt-get install make -y && \
+    pip install pipenv
 
 RUN pipenv install --dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-slim
 
-ENV PYTHONPATH /usr/src/app/src
+ENV PYTHONPATH=/usr/src/app/src
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.8-slim
+ARG PYTHON_VERSION="3.8"
+
+FROM python:${PYTHON_VERSION}-slim
 
 ENV PYTHONPATH=/usr/src/app/src
 

--- a/README.md
+++ b/README.md
@@ -73,18 +73,23 @@ def load(container_builder: ContainerBuilder):
 ```
 
 ## Running tests
-Build the docker image:
+
+### Build the docker image
+
 ```bash
 docker build . -t pypendency-dev
 ```
 
-The default settings build the test with Python 3.8. If you want to run the test suite against another Python version, pass the version in the `PYTHON_VERSION` build variable.
+The default settings build the image with Python 3.8. If you want to run the test suite against another Python version, pass the version in the `PYTHON_VERSION` build variable.
+
+For example:
 
 ```bash
 docker build . -t pypendency-dev --build-arg PYTHON_VERSION=3.10
 ```
 
-Run tests:
+### Run tests
+
 ```bash
 docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Build the docker image:
 docker build . -t pypendency-dev
 ```
 
+The default settings build the test with Python 3.8. If you want to run the test suite against another Python version, pass the version in the `PYTHON_VERSION` build variable.
+
+```bash
+docker build . -t pypendency-dev --build-arg PYTHON_VERSION=3.10
+```
+
 Run tests:
 ```bash
 docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"


### PR DESCRIPTION
This PR adds the missing `make` command to the Docker image.

Before the change:
```sh
$ docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"

Error: the command make could not be found within PATH or Pipfile's [scripts].
```

After the change:
```sh
$ docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"

python -m unittest
.............................................
----------------------------------------------------------------------
Ran 45 tests in 0.006s

OK
```

### Additional changes

1. Use the Docker image in the CI pipeline to unify the local and remote workflow.

2. Fix the syntax in the Dockerfile to avoid getting this warning while building the image:

```sh
$ docker build . -t pypendency-dev

[...]

 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
```
