### PR TITLE
PLATFORM-5905 - Make AttributeError handling more precise

### DIFF
--- a/src/pypendency/loaders/py_loader.py
+++ b/src/pypendency/loaders/py_loader.py
@@ -32,7 +32,9 @@ class PyLoader(Loader):
         try:
             module.load(self.__container_builder)
         except AttributeError as e:
-            raise exceptions.MissingLoaderMethod(resource) from e
+            if "has no attribute 'load'" in str(e):
+                raise exceptions.MissingLoaderMethod(resource) from e
+            raise e
 
     def load_by_module_name(self, resource: str) -> None:
         package = locate(resource)

--- a/src/pypendency/loaders/py_loader.py
+++ b/src/pypendency/loaders/py_loader.py
@@ -29,12 +29,10 @@ class PyLoader(Loader):
         self.__load_module(resource, module)
 
     def __load_module(self, resource: str, module: PythonLoadableModuleType) -> None:
-        try:
-            module.load(self.__container_builder)
-        except AttributeError as e:
-            if "has no attribute 'load'" in str(e):
-                raise exceptions.MissingLoaderMethod(resource) from e
-            raise e
+        if not hasattr(module, "load"):
+            raise exceptions.MissingLoaderMethod(resource)
+
+        module.load(self.__container_builder)
 
     def load_by_module_name(self, resource: str) -> None:
         package = locate(resource)

--- a/tests/loaders/test_py_loader.py
+++ b/tests/loaders/test_py_loader.py
@@ -44,6 +44,10 @@ class TestPyLoader(TestCase):
         with self.assertRaises(exceptions.MissingLoaderMethod):
             self.loader.load_by_module_name("tests.resources.test_di_no_load_method")
 
+    def test_load_by_module_name_fails_for_module_with_generic_attribute_error(self):
+        with self.assertRaises(AttributeError):
+            self.loader.load_by_module_name("tests.resources.test_di_with_generic_attribute_error")
+
     def test_load_by_module_name_works_as_expected(self):
         self.loader.load_by_module_name("tests.resources.test_di")
         c = self._container_builder.get("example.C")

--- a/tests/resources/test_di_with_generic_attribute_error.py
+++ b/tests/resources/test_di_with_generic_attribute_error.py
@@ -1,0 +1,12 @@
+from pypendency.argument import Argument
+from pypendency.builder import ContainerBuilder
+from pypendency.definition import Definition
+
+
+def load(container_builder: ContainerBuilder):
+    container_builder.set_definition(
+        Definition('example.A', 'tests.resources.class_a.A')
+    )
+
+    x = 42
+    x.append("This will cause an AttributeError")


### PR DESCRIPTION
## [PLATFORM-5905](https://feverup.atlassian.net/browse/PLATFORM-5905)

### 💡 Context
When Pypendency fails to load a module with an AttributeError, it assumes that it was because the DI file didn’t have a load() method. This isn’t always the case. For example, this code:

```python
def load(container_builder: ContainerBuilder):
    container_builder.set_definition(
        Definition('example.A', 'tests.resources.class_a.A')
    )

    x = 42
    x.append(1)
```

Would raise an exception like [this one](https://github.com/Feverup/pypendency/blob/b1879c0db90b65b0e87c05ea7e07eae11b4bb522/src/pypendency/loaders/exceptions.py#L20-L25):

```
Resource 'test_di_with_generic_attribute_error.py' requires loader method
```

When the problem is really that the method `append` doesn't exist in numbers.

### 📖 Summary
This PR improves the error handling mechanism by raising the unknown `AttributeError` in case it isn't caused by a missing `load` function

### ⚡️Performance Considerations
Negligible. Adds a string check when the module loading fails.

### 🧪 How should this be manually tested?
- [ ] Copy the `src/pypendency` folder and paste it the `src/` folder of a project that uses Pypendency. This will be enough for "patching" it
- [ ] Modify any python dependency injection file and add these changes inside the `load` method:
```
x = 42
x.append(1)
```
- [ ] Start the project and check that the error raised now is the `AttributeError` pointing at the `append()`, instead of mistakenly saying that  the `load()` function is missing

[PLATFORM-5905]: https://feverup.atlassian.net/browse/PLATFORM-5905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ