### PR TITLE
BDE-2483 - Move set_definition method to container

### DIFF
--- a/src/pypendency/builder.py
+++ b/src/pypendency/builder.py
@@ -1,6 +1,5 @@
 from typing import Optional, List
 
-from pypendency import exceptions
 from pypendency.container import Container
 from pypendency.definition import Definition
 
@@ -18,17 +17,6 @@ class ContainerBuilder(Container):
             cls._instance = cls([])
 
         return cls._instance
-
-    def set_definition(self, definition: Definition) -> None:
-        if self.is_resolved():
-            raise exceptions.ForbiddenChangeOnResolvedContainer()
-
-        if self.has(definition.identifier):
-            raise exceptions.ServiceAlreadyDefined(definition.identifier)
-
-        self._service_mapping.update({
-            definition.identifier: definition
-        })
 
 
 container_builder = ContainerBuilder.get_container_instance()

--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -82,6 +82,17 @@ class Container(AbstractContainer):
 
         return self._do_get(identifier)
 
+    def set_definition(self, definition: Definition) -> None:
+        if self.is_resolved():
+            raise exceptions.ForbiddenChangeOnResolvedContainer()
+
+        if self.has(definition.identifier):
+            raise exceptions.ServiceAlreadyDefined(definition.identifier)
+
+        self._service_mapping.update({
+            definition.identifier: definition
+        })
+
     def _do_get(self, identifier: str) -> Optional[object]:
         empty = object()
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,72 +1,13 @@
 from unittest import TestCase
-from unittest.mock import sentinel
 
-from pypendency import exceptions
-from pypendency.argument import Argument
 from pypendency.builder import ContainerBuilder
-from pypendency.definition import Definition
-from pypendency.tag import Tag
-from tests.resources.class_c import C
-
 
 class TestContainerBuilder(TestCase):
     def setUp(self) -> None:
         self.container_builder = ContainerBuilder([])
-        self.definition_a = Definition(
-            "example.A",
-            "tests.resources.class_a.A"
-        )
-        self.definition_b = Definition(
-            "example.B",
-            "tests.resources.class_b.B",
-            [Argument.no_kw_argument("@example.A")],
-        )
-        self.definition_c = Definition(
-            "example.C",
-            "tests.resources.class_c.C",
-            [
-                Argument.no_kw_argument("@example.A"),
-                Argument("kw_arg", "test_param"),
-                Argument("b", "@example.B"),
-            ],
-        )
-        self.definition_d = Definition(
-            "example.D",
-            "tests.resources.class_c.C",
-            [
-                Argument.no_kw_argument("@example.A"),
-                Argument("kw_arg", "test_param"),
-                Argument("b", "@example.B"),
-            ],
-            {
-                Tag(identifier="test_tag_A", value=sentinel.test_tag_A_value),
-            },
-        )
-        self.definition_e = Definition(
-            "example.E",
-            "tests.resources.class_a.A",
-            tags={
-                Tag(identifier="test_tag_A", value=sentinel.test_tag_A_value),
-                Tag(identifier="test_tag_B", value=sentinel.test_tag_B_value),
-            },
-        )
 
     def test_get_container_instance_retrieves_the_same_object(self):
         self.assertIs(
             ContainerBuilder.get_container_instance(),
             ContainerBuilder.get_container_instance()
         )
-
-    def test_set_definition_fails_if_resolved(self):
-        self.container_builder.resolve()
-
-        with self.assertRaises(exceptions.ForbiddenChangeOnResolvedContainer):
-            self.container_builder.set_definition(self.definition_a)
-
-    def test_set_definitions_sets_properly_so_services_can_be_retrieved(self):
-        self.container_builder.set_definition(self.definition_b)
-        self.container_builder.set_definition(self.definition_a)
-        self.container_builder.set_definition(self.definition_c)
-        self.container_builder.set_definition(self.definition_d)
-        self.container_builder.set_definition(self.definition_e)
-        self.assertIsInstance(self.container_builder.get("example.C"), C)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -42,10 +42,14 @@ class TestContainer(TestCase):
         )
         self.definition_e = Definition(
             "example.E",
-            "tests.resources.class_a.A",
-            tags={
+            "tests.resources.class_c.C",
+            [
+                Argument.no_kw_argument("@example.A"),
+                Argument("kw_arg", "test_param"),
+                Argument("b", "@example.B"),
+            ],
+            {
                 Tag(identifier="test_tag_A", value=sentinel.test_tag_A_value),
-                Tag(identifier="test_tag_B", value=sentinel.test_tag_B_value),
             },
         )
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -40,6 +40,14 @@ class TestContainer(TestCase):
                 Tag(identifier="test_tag_B", value=sentinel.test_tag_B),
             },
         )
+        self.definition_e = Definition(
+            "example.E",
+            "tests.resources.class_a.A",
+            tags={
+                Tag(identifier="test_tag_A", value=sentinel.test_tag_A_value),
+                Tag(identifier="test_tag_B", value=sentinel.test_tag_B_value),
+            },
+        )
 
     def test_is_resolved_is_false_on_instantiation(self):
         self.assertFalse(self.container.is_resolved())
@@ -305,3 +313,17 @@ class TestContainer(TestCase):
 
         with self.assertRaises(exceptions.TagNotFoundInContainer):
             container.get_services_identifiers_by_tag_name("this_tag_shouldn't_exist", None)
+
+    def test_set_definition_fails_if_resolved(self):
+        self.container.resolve()
+
+        with self.assertRaises(exceptions.ForbiddenChangeOnResolvedContainer):
+            self.container.set_definition(self.definition_a)
+
+    def test_set_definitions_sets_properly_so_services_can_be_retrieved(self):
+        self.container.set_definition(self.definition_b)
+        self.container.set_definition(self.definition_a)
+        self.container.set_definition(self.definition_c)
+        self.container.set_definition(self.definition_d)
+        self.container.set_definition(self.definition_e)
+        self.assertIsInstance(self.container.get("example.C"), C)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -36,8 +36,8 @@ class TestContainer(TestCase):
             "example.D",
             "tests.resources.class_a.A",
             tags={
-                Tag(identifier="test_tag_A", value=sentinel.test_tag_A),
-                Tag(identifier="test_tag_B", value=sentinel.test_tag_B),
+                Tag(identifier="test_tag_A", value=sentinel.test_tag_A_value),
+                Tag(identifier="test_tag_B", value=sentinel.test_tag_B_value),
             },
         )
         self.definition_e = Definition(
@@ -277,7 +277,7 @@ class TestContainer(TestCase):
                 "example.E",
                 "tests.resources.class_a.A",
                 tags={
-                    Tag(identifier="test_tag_A", value=sentinel.test_tag_A),
+                    Tag(identifier="test_tag_A", value=sentinel.test_tag_A_value),
                 },
             )
         ])
@@ -291,7 +291,7 @@ class TestContainer(TestCase):
             {
                 "msg": "With value",
                 "tag_identifier": "test_tag_A",
-                "tag_value": sentinel.test_tag_A,
+                "tag_value": sentinel.test_tag_A_value,
             },
         ]
 
@@ -310,7 +310,7 @@ class TestContainer(TestCase):
                 "example.E",
                 "tests.resources.class_a.A",
                 tags={
-                    Tag(identifier="test_tag_A", value=sentinel.test_tag_A),
+                    Tag(identifier="test_tag_A", value=sentinel.test_tag_A_value),
                 },
             )
         ])


### PR DESCRIPTION
## BDE-2483
[This PR is part of a series](https://github.com/search?q=org%3AFeverup+in%3Atitle+BDE-2483&type=pullrequests&s=created&o=asc)

### 💡 Context
While reviewing the library to do a talk about pypendency I have found some possible issues.

The `set_definition` function of ContainerBuilder makes it so that we are not following the single responsability principle. We could perfectly move this function to Container since it also handles definitions.

This way the only purpose of ContainerBuilder is being a singleton of Container.
And Container has all the code related to managing services, definitions and tags.

### 📖 Summary
This PR moves the set_definition function from ContainerBuilder to Container.

Note: The tests still pass since ContainerBuilder inherits from Container but we should probably move the set_definition tests to the Container test suite

### 🧪 How should this be manually tested?
You can manually run the tests with:
```sh
docker build . -t pypendency-dev
docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"
```