### PR TITLE
BDE-2483 - Typing change of tags mapping

### DIFF
--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -28,7 +28,7 @@ class Container(AbstractContainer):
             definition.identifier: definition
             for definition in definitions
         }
-        self._tags_mapping: Dict[Tag, List[str]] = {}
+        self._tags_mapping: Dict[Tag, Set[str]] = {}
 
     def resolve(self) -> None:
         if self.is_resolved():


### PR DESCRIPTION
## BDE-2483
[This PR is part of a series](https://github.com/search?q=org%3AFeverup+in%3Atitle+BDE-2483&type=pullrequests&s=created&o=asc)

### 💡 Context
While reviewing the library to do a talk about pypendency I have found some possible issues.

There is currently a warning in this [line](https://github.com/Feverup/pypendency/blob/918eb1ad1f6764685f8f52cd2202f33e380fc4d2/src/pypendency/container.py#L52):
![image](https://github.com/user-attachments/assets/b88db7c7-e136-40be-b4a0-abcb0e97ab13)

The issue is that we type `_tags_mapping` as a `dict[tag, list(str)]` [here](https://github.com/Feverup/pypendency/blob/918eb1ad1f6764685f8f52cd2202f33e380fc4d2/src/pypendency/container.py#L31)
![image](https://github.com/user-attachments/assets/55a2b011-5772-4147-b6be-614e2fad508b)
so there is a mismatch with the defined type and the actual value

typing the `_tags_mapping` with the proper type solves the warning.

### 📖 Summary
This PR changes the type definition of `_tags_mapping` to `dict[tag, set(str)]` 

### 🧪 How should this be manually tested?
You can manually run the tests with:
```sh
docker build . -t pypendency-dev
docker run -v $(pwd)/.:/usr/src/app pypendency-dev bash -c "pipenv run make run-tests"
```