### PR TITLE
Update AbstractContainer get method return type

### DIFF
--- a/src/pypendency/container.py
+++ b/src/pypendency/container.py
@@ -14,7 +14,7 @@ class AbstractContainer(ABC):
     def set(self, identifier: str, service: object) -> None: pass
 
     @abstractmethod
-    def get(self, identifier: str) -> Optional[object]: pass
+    def get(self, identifier: str) -> Any: pass
 
     @abstractmethod
     def has(self, identifier: str) -> bool: pass
@@ -76,7 +76,7 @@ class Container(AbstractContainer):
     def has(self, identifier: str) -> bool:
         return identifier in self._service_mapping
 
-    def get(self, identifier: str) -> Optional[object]:
+    def get(self, identifier: str) -> Any:
         if self.is_resolved() is False:
             self.resolve()
 
@@ -93,7 +93,7 @@ class Container(AbstractContainer):
             definition.identifier: definition
         })
 
-    def _do_get(self, identifier: str) -> Optional[object]:
+    def _do_get(self, identifier: str) -> Any:
         empty = object()
 
         service = self._service_mapping.get(identifier, empty)


### PR DESCRIPTION
Update the return type for the `get` method in `AbstractContainer` and its implementation to improve type flexibility. 

The change replaces `Optional[object]` with `Any` as both `get` and `_do_get` methods depends on `__instance_from_fqn` method which returns `Any` type.
